### PR TITLE
Fix struct.error when unpacking response from bmp180

### DIFF
--- a/bmp180.py
+++ b/bmp180.py
@@ -150,9 +150,9 @@ class BMP180():
         next(self.gauge)
         self.temperature  # Populate self.B5_raw
         try:
-            MSB = unp('<h', self.MSB_raw)[0]
-            LSB = unp('<h', self.LSB_raw)[0]
-            XLSB = unp('<h', self.XLSB_raw)[0]
+            MSB = unp('B', self.MSB_raw)[0]
+            LSB = unp('B', self.LSB_raw)[0]
+            XLSB = unp('B', self.XLSB_raw)[0]
         except:
             return 0.0
         UP = ((MSB << 16)+(LSB << 8)+XLSB) >> (8-self.oversample_setting)


### PR DESCRIPTION
BMP180 pressure data is stored in single byte registers. When read, the response should be unpacked as a single byte instead of a short.

This resolves a `struct.error` exception which was preventing the pressure from being correctly reported from the sensor.

```
>>> bmp180.pressure
b'\x9e'
b'0'
b'@'
96486.3
>>> bmp180.altitude
b'\x9e'
b'4'
b'\xc0'
389.85
```

The fix works on my sensor, although the values are a bit off the expected results.

Unfortunately I have only one BMP180 sensor to test with, so I cannot confirm the source of the inconsistency between expected and measured values.