### PR TITLE
Fix pin assignments for ESP8266

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Example:
 from bmp180 import BMP180
 from machine import I2C, Pin                        # create an I2C bus object accordingly to the port you are using
 bus = I2C(1, baudrate=100000)           # on pyboard
-# bus =  I2C(scl=Pin(4), sda=Pin(5), freq=100000)   # on esp8266
+# bus =  I2C(scl=Pin(5), sda=Pin(4), freq=100000)   # on esp8266
 bmp180 = BMP180(bus)
 bmp180.oversample_sett = 2
 bmp180.baseline = 101325


### PR DESCRIPTION
Just a small fix for the pin assignments on the ESP8266 in the example code in README.md.